### PR TITLE
Dracut: Set nullglob when installing the module

### DIFF
--- a/dracut/71prefixdevname/module-setup.sh
+++ b/dracut/71prefixdevname/module-setup.sh
@@ -6,7 +6,12 @@ check() {
 }
 
 install() {
+    orig_shopt="$(shopt -p nullglob)"
+    shopt -q -u nullglob
+
     if dracut_module_included "systemd"; then
         inst_multiple -H -o /etc/systemd/network/71-net-ifnames-prefix-*.link
     fi
+
+    eval "$orig_shopt"
 }


### PR DESCRIPTION
Module scripts that belong to other modules might perform modification
of the shell options and not perform clean up afterwards. In a case when
the shell option 'nullglob' is set, the installation of prefixdevname
fails as the glob expression used gets expanded to a null string when no
path exists, and no arguments are passed to 'inst_multiple' (the
installation fails due to no arguments provided). This patch makes sure
that the 'nullglob' option is unset and restored it afterwards.