### PR TITLE
Fix errors

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -186,7 +186,7 @@ impl NetSetupLinkConfig {
         NetSetupLinkConfig::match_ethernet_links(&mut enumerate)?;
 
         for device in enumerate.scan_devices()? {
-            let name = device.sysname().to_str().ok_or("Failed to convert from ffi::OsStr to &str");
+            let name = device.sysname().unwrap().to_str().ok_or("Failed to convert from ffi::OsStr to &str");
 
             if ! name?.to_string().starts_with(&self.ifname_prefix) {
                 continue;

--- a/src/config.rs
+++ b/src/config.rs
@@ -256,8 +256,8 @@ impl NetSetupLinkConfig {
 
             let hwaddr = mac;
 
-            self.config.insert(hwaddr.to_string(), PrefixedLink::new(name)?);
-            self.links.push(PrefixedLink::new_with_hwaddr(name, hwaddr)?);
+            self.config.insert(hwaddr.to_string(), PrefixedLink::new(&name)?);
+            self.links.push(PrefixedLink::new_with_hwaddr(&name, &hwaddr)?);
         }
         Ok(())
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,8 +6,10 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::env;
 use std::path::PathBuf;
-use libudev;
 use regex::Regex;
+
+extern crate libudev;
+use libudev::Device;
 
 use sema::*;
 
@@ -76,7 +78,7 @@ pub fn hwaddr_from_event_device() -> Result<String, Box<Error>> {
 
     syspath.push_str(&devpath);
 
-    let attr = udev.device_from_syspath(&PathBuf::from(syspath))?.attribute_value("address").ok_or("Failed to get MAC Address")?.to_owned();
+    let attr = Device::from_syspath(&udev, &PathBuf::from(syspath))?.attribute_value("address").ok_or("Failed to get MAC Address")?.to_owned();
     let addr = hwaddr_normalize(&attr.to_str().ok_or("Failed to convert OsStr to String")?.to_string())?;
 
     Ok(addr)


### PR DESCRIPTION
1. Fix error[E0277] - the size for values of type `str` cannot be known at compilation time
2. fix: Add missing `unwrap` on `device.sysname()`

```rust
error[E0599]: no method named `to_str` found for enum `Option` in the current scope
   --> src/config.rs:189:41
    |
189 |             let name = device.sysname().to_str().ok_or("Failed to convert from ffi::OsStr to &str");
    |                                         ^^^^^^ method not found in `Option<&OsStr>`
```
3. fix(libudev): Use Device::from_syspath() instead of `context.device_from_syspath()`

`libudev v0.3.0` have moved `Context::device_from_syspath()` to `Device::from_syspath()`

Release notes: https://github.com/dcuddeback/libudev-rs/releases/tag/v0.3.0