### PR TITLE
fix: 71prefixdevname module, use depends

### DIFF
--- a/dracut/71prefixdevname/module-setup.sh
+++ b/dracut/71prefixdevname/module-setup.sh
@@ -5,13 +5,15 @@ check() {
     return 0
 }
 
+depends() {
+  echo systemd
+}
+
 install() {
     orig_shopt="$(shopt -p nullglob)"
     shopt -q -u nullglob
 
-    if dracut_module_included "systemd"; then
-        inst_multiple -H -o /etc/systemd/network/71-net-ifnames-prefix-*.link
-    fi
+    inst_multiple -H -o /etc/systemd/network/71-net-ifnames-prefix-*.link
 
     eval "$orig_shopt"
 }


### PR DESCRIPTION
use dracut function `depends()` instead of the "manual" check for `systemd` in the install function.

This should be cleaner and potentially easier to debug.