### PR TITLE
Drop winapi libs from vendoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ dist:
 vendor:
 	@rm -rf vendor
 	@cargo vendor
+	@rm -f vendor/winapi*/lib/*
 	@tar -czf $(VENDOR) vendor
 
 srpm: dist


### PR DESCRIPTION
This is a linux-specific package, so the winapi libs will never be used, and just bloat the vendor tarball.